### PR TITLE
change to 6 D&D abilities for character typeclass

### DIFF
--- a/commands/command.py
+++ b/commands/command.py
@@ -47,8 +47,9 @@ class CmdAbilities(Command):
 
     def func(self):
         "main function of the command"
-        str, agi, mag = self.caller.get_abilities()
-        string = "STR: %s, AGI: %s, MAG: %s" % (str, agi, mag)
+        str, int, wis, dex, con, cha = self.caller.get_abilities()
+        string = ("STR: %s, INT: %s, WIS: %s, DEX: %s, CON: %s, " 
+                "CHA: %s") % (str, int, wis, dex, con, cha)
         self.caller.msg(string)
     pass
 

--- a/commands/tests.py
+++ b/commands/tests.py
@@ -29,5 +29,5 @@ class TestAbilities(CommandTest):
     character_typeclass = Character
 
     def test_simple(self):
-        self.call(CmdAbilities(), "", "STR: 5, AGI: 4, MAG: 2")
+        self.call(CmdAbilities(), "", "STR: 0, INT: 0, WIS: 0, DEX: 0, CON: 0, CHA: 0")
 

--- a/typeclasses/characters.py
+++ b/typeclasses/characters.py
@@ -37,15 +37,19 @@ class Character(DefaultCharacter):
         """
 
         # set persistent attributes
-        self.db.strength = 5
-        self.db.agility = 4
-        self.db.magic = 2
+        self.db.strength = 0
+        self.db.intelligence = 0
+        self.db.wisdom = 0
+        self.db.dexterity = 0
+        self.db.constitution = 0
+        self.db.charisma = 0
 
     def get_abilities(self):
         """
         Simple access method to return ability
         scores as a tuple (str,agi,mag)
         """
-        return self.db.strength, self.db.agility, self.db.magic
+        return ( self.db.strength, self.db.intelligence, self.db.wisdom, 
+            self.db.dexterity, self.db.constitution, self.db.charisma)
 
     pass


### PR DESCRIPTION
This makes characters start with str, int, wis, dex, con, and cha.  All scores start at 0 for now. For reasons.